### PR TITLE
实现向客户端的回复缓冲区写入回复信息的接口

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+
+    <property name="charset" value="UTF-8"/>
+    <property name="severity" value="warning"/>
+
+    <!-- 检查文件的长度（行） default max=2000 -->
+    <module name="FileLength">
+        <property name="max" value="2500"/>
+    </module>
+
+    <!-- 每行字符数 -->
+    <module name="LineLength">
+        <property name="max" value="120"/>
+    </module>
+
+    <module name="TreeWalker">
+
+        <!-- 必须导入类的完整路径，即不能使用*导入所需的类 -->
+        <module name="AvoidStarImport"/>
+
+        <!-- 检查是否从非法的包中导入了类 illegalPkgs: 定义非法的包名称-->
+        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+
+        <!-- 检查是否导入了不必显示导入的类-->
+        <module name="RedundantImport"/>
+
+        <!-- 检查是否导入的包没有使用-->
+        <module name="UnusedImports"/>
+
+        <!--option: 定义左大括号'{'显示位置，eol在同一行显示，nl在下一行显示
+          maxLineLength: 大括号'{'所在行行最多容纳的字符数
+          tokens: 该属性适用的类型，例：CLASS_DEF,INTERFACE_DEF,METHOD_DEF,CTOR_DEF -->
+        <module name="LeftCurly">
+            <property name="option" value="eol"/>
+        </module>
+
+        <!-- NeedBraces 检查是否应该使用括号的地方没有加括号
+          tokens: 定义检查的类型 -->
+        <module name="NeedBraces"/>
+
+        <!-- 检查在重写了equals方法后是否重写了hashCode方法 -->
+        <module name="EqualsHashCode"/>
+
+        <!--  Checks for illegal instantiations where a factory method is preferred.
+          Rationale: Depending on the project, for some classes it might be preferable to create instances through factory methods rather than calling the constructor.
+          A simple example is the java.lang.Boolean class. In order to save memory and CPU cycles, it is preferable to use the predefined constants TRUE and FALSE. Constructor invocations should be replaced by calls to Boolean.valueOf().
+          Some extremely performance sensitive projects may require the use of factory methods for other classes as well, to enforce the usage of number caches or object pools. -->
+        <module name="IllegalInstantiation">
+            <property name="classes" value="java.lang.Boolean"/>
+        </module>
+
+        <!-- Checks for Naming Conventions.   命名规范   -->
+        <!-- local, final variables, including catch parameters -->
+        <module name="LocalFinalVariableName"/>
+
+        <!-- local, non-final variables, including catch parameters-->
+        <module name="LocalVariableName"/>
+
+        <!-- static, non-final fields -->
+        <module name="StaticVariableName">
+            <property name="format" value="(^[a-z][a-z0-9][a-zA-Z0-9]{0,19}$)"/>
+        </module>
+
+        <!-- packages -->
+        <module name="PackageName" >
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+        </module>
+
+        <!-- classes and interfaces -->
+        <module name="TypeName">
+            <property name="format" value="(^[A-Z][a-zA-Z0-9]{0,19}$)"/>
+        </module>
+
+        <!-- methods -->
+        <module name="MethodName">
+            <property name="format" value="(^[a-z][a-zA-Z0-9]{0,19}$)"/>
+        </module>
+
+        <!-- non-static fields -->
+        <module name="MemberName">
+            <property name="format" value="(^[a-z][a-z0-9][a-zA-Z0-9]{0,19}$)"/>
+        </module>
+
+        <!-- parameters -->
+        <module name="ParameterName">
+            <property name="format" value="(^[a-z][a-zA-Z0-9_]{0,19}$)"/>
+        </module>
+
+        <!-- constants (static,  final fields) -->
+        <module name="ConstantName">
+            <property name="format" value="(^[A-Z0-9_]{0,19}$)"/>
+        </module>
+
+        <!-- 代码缩进   -->
+        <module name="Indentation">
+        </module>
+
+        <!--  Checks for overly complicated boolean expressions. Currently finds code like  if (b == true), b || true, !false, etc.
+          检查boolean值是否冗余的地方
+          Rationale: Complex boolean logic makes code hard to understand and maintain. -->
+        <module name="SimplifyBooleanExpression"/>
+
+        <!--  Checks for overly complicated boolean return statements. For example the following code
+           检查是否存在过度复杂的boolean返回值
+           if (valid())
+              return false;
+           else
+              return true;
+           could be written as
+              return !valid();
+           The Idea for this Check has been shamelessly stolen from the equivalent PMD rule. -->
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- Checks that a class which has only private constructors is declared as final.只有私有构造器的类必须声明为final-->
+        <module name="FinalClass"/>
+
+        <!--  Checks visibility of class members. Only static final members may be public; other class members must be private unless property protectedAllowed or packageAllowed is set.
+          检查class成员属性可见性。只有static final 修饰的成员是可以public的。其他的成员属性必需是private的，除非属性protectedAllowed或者packageAllowed设置了true.
+           Public members are not flagged if the name matches the public member regular expression (contains "^serialVersionUID$" by default). Note: Checkstyle 2 used to include "^f[A-Z][a-zA-Z0-9]*$" in the default pattern to allow CMP for EJB 1.1 with the default settings. With EJB 2.0 it is not longer necessary to have public access for persistent fields, hence the default has been changed.
+           Rationale: Enforce encapsulation. 强制封装 -->
+        <module name="VisibilityModifier"/>
+
+        <!-- 每一行只能定义一个变量 -->
+        <module name="MultipleVariableDeclarations">
+        </module>
+
+        <!-- Checks the style of array type definitions. Some like Java-style: public static void main(String[] args) and some like C-style: public static void main(String args[])
+          检查再定义数组时，采用java风格还是c风格，例如：int[] num是java风格，int num[]是c风格。默认是java风格-->
+        <module name="ArrayTypeStyle">
+        </module>
+
+        <!-- A check for TODO: comments. Actually it is a generic regular expression matcher on Java comments. To check for other patterns in Java comments, set property format.
+           检查是否存在TODO（待处理） TODO是javaIDE自动生成的。一般代码写完后要去掉。
+         -->
+        <module name="TodoComment"/>
+
+        <!--  Checks that long constants are defined with an upper ell. That is ' L' and not 'l'. This is in accordance to the Java Language Specification,  Section 3.10.1.
+          检查是否在long类型是否定义了大写的L.字母小写l和数字1（一）很相似。
+          looks a lot like 1. -->
+        <module name="UpperEll"/>
+
+        <!--  Checks that switch statement has "default" clause. 检查switch语句是否有‘default’从句
+           Rationale: It's usually a good idea to introduce a default case in every switch statement.
+           Even if the developer is sure that all currently possible cases are covered, this should be expressed in the default branch,
+            e.g. by using an assertion. This way the code is protected aginst later changes, e.g. introduction of new types in an enumeration type. -->
+        <module name="MissingSwitchDefault"/>
+
+        <!--检查switch中case后是否加入了跳出语句，例如：return、break、throw、continue -->
+        <module name="FallThrough"/>
+
+        <!-- Checks the number of parameters of a method or constructor. max default 7个. -->
+        <module name="ParameterNumber">
+            <property name="max" value="7"/>
+        </module>
+
+
+        <!-- Checks for long methods and constructors. max default 150行. max=300 设置长度300 -->
+        <module name="MethodLength">
+            <property name="max" value="300"/>
+        </module>
+
+        <!-- ModifierOrder 检查修饰符的顺序，默认是 public,protected,private,abstract,static,final,transient,volatile,synchronized,native -->
+        <module name="ModifierOrder">
+        </module>
+
+        <!-- 检查是否有多余的修饰符，例如：接口中的方法不必使用public、abstract修饰  -->
+        <module name="RedundantModifier">
+        </module>
+
+        <!--- 字符串比较必须使用 equals() -->
+        <module name="StringLiteralEquality">
+        </module>
+
+        <!-- if-else嵌套语句个数 最多4层 -->
+        <module name="NestedIfDepth">
+            <property name="max" value="3"/>
+        </module>
+
+        <!-- try-catch 嵌套语句个数 最多2层 -->
+        <module name="NestedTryDepth">
+            <property name="max" value="2"/>
+        </module>
+
+    </module>
+
+</module>

--- a/src/main/java/command/AbstractCommand.java
+++ b/src/main/java/command/AbstractCommand.java
@@ -1,7 +1,5 @@
 package command;
 
-import server.PandisServer;
-
 /**
  * @Description Command接口的骨架实现，具体Command实现都应该继承该骨架实现
  * @Author huzihan

--- a/src/main/java/common/store/Sds.java
+++ b/src/main/java/common/store/Sds.java
@@ -1,5 +1,6 @@
 package common.store;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /**
@@ -252,7 +253,7 @@ public class Sds implements Comparable<Sds> {
     }
 
     public Sds cat(char[] c) {
-        Sds s = Sds.createSds(new String(c).getBytes());
+        Sds s = Sds.createSds(new String(c).getBytes(StandardCharsets.UTF_8));
         return this.cat(s, s.getLen());
     }
 

--- a/src/main/java/event/AcceptTcpHandler.java
+++ b/src/main/java/event/AcceptTcpHandler.java
@@ -24,7 +24,7 @@ import java.nio.channels.SocketChannel;
 public class AcceptTcpHandler implements FileEventHandler{
     private static Log logger = LogFactory.getLog(AcceptTcpHandler.class);
 
-    private volatile static AcceptTcpHandler instance;
+    private static volatile AcceptTcpHandler instance;
 
     private AcceptTcpHandler() {
         super();
@@ -77,7 +77,7 @@ public class AcceptTcpHandler implements FileEventHandler{
         try {
             server.getEventLoop().registerFileEvent(socketChannel, SelectionKey.OP_READ, ReadQueryFromClientHandler.getHandler(), newClient);
         } catch (ClosedChannelException e) {
-            e.printStackTrace();
+            logger.info("Register event on channel" + socketChannel.toString() + "faild");
         }
 
         return true;

--- a/src/main/java/event/ReadQueryFromClientHandler.java
+++ b/src/main/java/event/ReadQueryFromClientHandler.java
@@ -5,10 +5,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import server.PandisServer;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
-import java.nio.channels.SocketChannel;
 
 /**
  * 读取客户端的查询缓冲区内容
@@ -17,7 +14,8 @@ import java.nio.channels.SocketChannel;
  */
 public class ReadQueryFromClientHandler implements FileEventHandler{
     private static Log logger = LogFactory.getLog(ReadQueryFromClientHandler.class);
-    private volatile static ReadQueryFromClientHandler instance;
+
+    private static volatile ReadQueryFromClientHandler instance;
 
     private ReadQueryFromClientHandler() {
         super();

--- a/src/main/java/event/SendApplyToClientHandler.java
+++ b/src/main/java/event/SendApplyToClientHandler.java
@@ -1,0 +1,47 @@
+package event;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import server.PandisServer;
+
+import java.nio.channels.SelectionKey;
+
+/**
+ * @description: 将客户端回复缓冲区内的内容发送给客户端
+ * @author: huzihan
+ * @create: 2021-07-22
+ */
+public class SendApplyToClientHandler implements FileEventHandler{
+    private static Log logger = LogFactory.getLog(SendApplyToClientHandler.class);
+
+    private static volatile SendApplyToClientHandler instance;
+
+    private SendApplyToClientHandler() {
+        super();
+    }
+
+    public static SendApplyToClientHandler getHandler() {
+        if (instance == null) {
+            synchronized (SendApplyToClientHandler.class) {
+                if (instance == null) {
+                    instance = new SendApplyToClientHandler();
+                }
+            }
+        }
+
+        return instance;
+    }
+
+    /**
+     * 将客户端回复缓冲区内的内容发送给客户端
+     * @param server
+     * @param key
+     * @param privateData
+     * @return
+     */
+    @Override
+    public boolean handle(PandisServer server, SelectionKey key, Object privateData) {
+        logger.info("测试：服务器发送回复给客户端");
+        return true;
+    }
+}

--- a/src/main/java/protocol/ReplyType.java
+++ b/src/main/java/protocol/ReplyType.java
@@ -1,0 +1,78 @@
+package protocol;
+
+/**
+ * @description: Pandis消息回复的5种类型
+ * @author: huzihan
+ * @create: 2021-07-22
+ */
+public enum ReplyType {
+
+    ERROR {
+        public String buildReplyByTemplate(String args) {
+            StringBuilder message = new StringBuilder();
+            message.append(ERROR_PREFIX);
+            message.append(args);
+            message.append(TERMINATOR);
+
+            return message.toString();
+        }
+    },      // 错误信息
+    STATUS {
+        public String buildReplyByTemplate(String args) {
+            StringBuilder message = new StringBuilder();
+            message.append(STATUS_PREFIX);
+            message.append(args);
+            message.append(TERMINATOR);
+
+            return message.toString();
+        }
+
+    },      // 状态回复
+    INTEGER {
+        public String buildReplyByTemplate(String args) {
+            StringBuilder message = new StringBuilder();
+            message.append(INTEGER_PREFIX);
+            message.append(args);
+            message.append(TERMINATOR);
+
+            return message.toString();
+        }
+    },      // 整数回复
+    BULK {
+        public String buildReplyByTemplate(String args) {
+            StringBuilder message = new StringBuilder();
+            message.append(BULK_PREFIX);
+            message.append(args.length());
+            message.append(TERMINATOR);
+            message.append(args);
+            message.append(TERMINATOR);
+            return message.toString();
+        }
+    },      // 字符串回复
+    MULTI_BULK {
+        // WARNING: 这里的实现有问题，由于多行回复可能需要传入很多数据，这里可能暂时难以构建
+        public String buildReplyByTemplate(String args) {
+            StringBuilder message = new StringBuilder();
+            message.append(MULTI_BULK_PREFIX);
+            message.append(args);
+            message.append(TERMINATOR);
+
+            return message.toString();
+        }
+    };      // 多行字符串回复
+
+    public static final String ERROR_PREFIX = "-ERR ";
+    public static final String STATUS_PREFIX = "+";
+    public static final String INTEGER_PREFIX = ":";
+    public static final String BULK_PREFIX = "$";
+    public static final String MULTI_BULK_PREFIX = "*";
+    public static final String TERMINATOR = "\r\n";
+
+    /**
+     * 基于模板，填入传入的参数生成回复消息
+     * 不同的回复消息类型有不同的模板
+     * @param args 参数
+     * @return 构建的消息
+     */
+    public abstract String buildReplyByTemplate(String args);
+}

--- a/src/main/java/protocol/RequestType.java
+++ b/src/main/java/protocol/RequestType.java
@@ -1,10 +1,12 @@
 package protocol;
 
 /**
- * @description:
+ * @description: 请求类型
  * @author: huzihan
  * @create: 2021-07-19
  */
 public enum RequestType {
-    NONE, MULTI_BULK, INLINE
+    NONE,
+    MULTI_BULK, // 统一请求协议类型
+    INLINE;     // 简单协议类型
 }


### PR DESCRIPTION
实现向客户端的回复缓冲区写入回复信息的接口。
当服务器执行完命令或发送错误时需要向客户端发送信息，这些信息回先缓存到对应的客户端结构的回复缓冲区或缓冲队列中。
按照redis中的实现，应该有5类消息：
* 错误消息
* 状态消息
* 整数消息
* 字符串消息
* 多行字符串消息

不同类型的消息回使用特殊的符号和结构来标识。
该pr初步实现来构建不同种类消息的接口和将消息写入客户端回复缓冲区的接口。

@gaolijiemathcs @yaohua-H 
